### PR TITLE
Update compile-adcirc-netcdf.md

### DIFF
--- a/compile-adcirc-netcdf.md
+++ b/compile-adcirc-netcdf.md
@@ -154,7 +154,7 @@ On the line that sets the ```DEPDIR``` directory, change the value to the locati
 Finally, compile ADCIRC using the following command:
 
 ```bash
-make adcirc padcirc adcprep NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable NETCDFHOME=/home/atdyer/adcirc/dependencies/install/
+make adcirc padcirc adcprep NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable
 ```
 
 Again, making sure to point NETCDFHOME towards the installation directory. Once make has finished, you should have the ```adcirc```, ```padcirc```, and ```adcprep``` executables in the work directory.


### PR DESCRIPTION
" Finally, compile ADCIRC using the following command:
make adcirc padcirc adcprep NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable NETCDFHOME=/home/user7/Ocean_dynamic/ADCIRC/dependencies/install/ "

" NETCDFHOME=/home/user7/Ocean_dynamic/ADCIRC/dependencies/install/  "
Please remove this line because some time cross compilation didn't accept it ....othewrwise its give netcdf io error (porting) 
and change ...dependencies/install// TO ....dependencies/install/ for LD_LIBRARY_PATH

using the following command:
make adcirc padcirc adcprep NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable

Regards, Subhadeep Maishal
              Birla Institute of Technology, Mesra ,India.